### PR TITLE
Responses table view: Allow groupEdit to be a text box (not just a select box)

### DIFF
--- a/scripts/src/__tests__/admin/__snapshots__/ResponseTableView.unit.test.tsx.snap
+++ b/scripts/src/__tests__/admin/__snapshots__/ResponseTableView.unit.test.tsx.snap
@@ -179,38 +179,40 @@ exports[`renders response table with an editSchema specified instead of a group 
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      value="v1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      AAA
-                    </option>
-                    <option
-                      value="v2"
-                    >
-                      BBB
-                    </option>
-                    <option
-                      value="v3"
-                    >
-                      CCC
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        value="v1"
+                      >
+                        AAA
+                      </option>
+                      <option
+                        value="v2"
+                      >
+                        BBB
+                      </option>
+                      <option
+                        value="v3"
+                      >
+                        CCC
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -260,38 +262,40 @@ exports[`renders response table with an editSchema specified instead of a group 
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      value="v1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      AAA
-                    </option>
-                    <option
-                      value="v2"
-                    >
-                      BBB
-                    </option>
-                    <option
-                      value="v3"
-                    >
-                      CCC
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        value="v1"
+                      >
+                        AAA
+                      </option>
+                      <option
+                        value="v2"
+                      >
+                        BBB
+                      </option>
+                      <option
+                        value="v3"
+                      >
+                        CCC
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -748,34 +752,36 @@ exports[`renders response table with an undefined group assign 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      selected=""
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        selected=""
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -839,34 +845,36 @@ exports[`renders response table with an undefined group assign 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      selected=""
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        selected=""
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -1110,34 +1118,36 @@ exports[`renders response table with default filter 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      selected=""
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        selected=""
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -1187,34 +1197,36 @@ exports[`renders response table with default filter 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      selected=""
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        selected=""
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -2180,34 +2192,36 @@ exports[`renders response table with group assign 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      selected=""
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        selected=""
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>
@@ -2271,34 +2285,36 @@ exports[`renders response table with group assign 1`] = `
               style="flex:100 0 auto;width:100px"
             >
               <div
-                class="rjsf"
+                class="ccmt-cff-Page-FormPage"
               >
                 <div
-                  class="form-group field field-string"
+                  autocomplete="false"
+                  class="rjsf"
                 >
-                  <select
-                    class="form-control"
-                    id="root"
+                  <div
+                    class="form-group field field-string"
                   >
-                    <option
-                      value=""
-                    />
-                    <option
-                      selected=""
-                      value="CLASS1"
+                    <select
+                      class="form-control"
+                      id="root"
                     >
-                      Class Name One
-                    </option>
-                    <option
-                      value="CLASS2"
-                    >
-                      Class Name Two
-                    </option>
-                  </select>
+                      <option
+                        value=""
+                      />
+                      <option
+                        selected=""
+                        value="CLASS1"
+                      >
+                        Class Name One
+                      </option>
+                      <option
+                        value="CLASS2"
+                      >
+                        Class Name Two
+                      </option>
+                    </select>
+                  </div>
                 </div>
-                <div
-                  class="d-none"
-                />
               </div>
             </div>
           </div>

--- a/scripts/src/admin/ResponseTable/ResponseTableView.tsx
+++ b/scripts/src/admin/ResponseTable/ResponseTableView.tsx
@@ -78,7 +78,7 @@ export default (props: IResponseTableViewProps) => {
         columns={[actionsHeader, ...headers]}
         minRows={0}
         filterable
-        defaultSorted={[{ id: "DATE_LAST_MODIFIED", desc: true }]}
+        defaultSorted={[{ id: "DATE_CREATED", desc: true }]}
         defaultFiltered={[{ id: "PAID", value: "all" }]}
         defaultFilterMethod={filterCaseInsensitive}
       />

--- a/scripts/src/admin/util/Headers.tsx
+++ b/scripts/src/admin/util/Headers.tsx
@@ -8,6 +8,7 @@ import { filterCaseInsensitive } from "../ResponseTable/filters";
 import { dataToSchemaPath } from "../util/SchemaUtil";
 import ExpressionParser from "../../common/ExpressionParser";
 import moment from "moment";
+import CustomForm from "../../form/CustomForm";
 
 export interface IHeaderObject {
   Header: string;
@@ -395,11 +396,16 @@ export namespace Headers {
           .map(e => formatValue(e))
       };
     }
+    const hasEnum = !!selectSchema.enum;
     headerObj.headerClassName = "ccmt-cff-no-click";
     headerObj.Cell = row => (
-      <Form
+      <CustomForm
         schema={selectSchema}
-        uiSchema={{ "ui:widget": "select" }}
+        uiSchema={
+          hasEnum
+            ? { "ui:widget": "select" }
+            : { "ui:widget": "cff:submitInputGroup" }
+        }
         formData={row.value}
         onChange={e => {
           if (typeof e.formData === "undefined") return;
@@ -412,16 +418,24 @@ export namespace Headers {
         }}
         tagName="div"
       >
-        <div className="d-none"></div>
-      </Form>
+        <></>
+      </CustomForm>
     );
     headerObj.filterMethod = filterMethodAllNone;
     let selectSchemaFilter = cloneDeep(selectSchema);
-    selectSchemaFilter.enum.unshift("CFF_FILTER_NONE");
-    selectSchemaFilter.enumNames.unshift("None");
-    selectSchemaFilter.enum.unshift("CFF_FILTER_DEFINED");
-    selectSchemaFilter.enumNames.unshift("Defined");
+    if (selectSchemaFilter.enum) {
+      selectSchemaFilter.enum.unshift("CFF_FILTER_NONE");
+      selectSchemaFilter.enum.unshift("CFF_FILTER_DEFINED");
+    }
+    if (selectSchemaFilter.enumNames) {
+      selectSchemaFilter.enumNames.unshift("None");
+      selectSchemaFilter.enumNames.unshift("Defined");
+    }
     headerObj.Filter = ({ filter, onChange }) => {
+      if (!hasEnum) {
+        // No filter if there is no select schema
+        return null;
+      }
       if (!filter && headerOption.defaultFilter) {
         class Loader extends React.Component {
           componentDidMount() {

--- a/scripts/src/form/CustomForm.tsx
+++ b/scripts/src/form/CustomForm.tsx
@@ -23,6 +23,7 @@ import ConditionalHiddenRadioWidget from "./form_widgets/ConditionalHiddenRadioW
 import InfoboxRadioWidget from "./form_widgets/InfoboxRadioWidget";
 import InfoboxSelectWidget from "./form_widgets/InfoboxSelectWidget";
 import RemovedWidget from "./form_widgets/RemovedWidget";
+import SubmitInputGroupWidget from "./form_widgets/SubmitInputGroupWidget";
 import DynamicEnumField from "./form_widgets/DynamicEnumField";
 import AddressAutocompleteField from "./form_widgets/AddressAutocompleteField";
 import { IResponseMetadata } from "./interfaces";
@@ -76,7 +77,8 @@ const widgets = {
   "cff:conditionalHiddenRadio": ConditionalHiddenRadioWidget,
   "cff:infoboxRadio": InfoboxRadioWidget,
   "cff:infoboxSelect": InfoboxSelectWidget,
-  "cff:removed": RemovedWidget
+  "cff:removed": RemovedWidget,
+  "cff:submitInputGroup": SubmitInputGroupWidget
 };
 
 const fields = {

--- a/scripts/src/form/form_widgets/SubmitInputGroupWidget.scss
+++ b/scripts/src/form/form_widgets/SubmitInputGroupWidget.scss
@@ -1,0 +1,10 @@
+div.cff-submitinputgroupwidget {
+  .form-group {
+    padding-right: 0px !important;
+  }
+  .icon {
+    font-size: .8em;
+    float: right;
+    display: block;
+  }
+}

--- a/scripts/src/form/form_widgets/SubmitInputGroupWidget.tsx
+++ b/scripts/src/form/form_widgets/SubmitInputGroupWidget.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import Form from "react-jsonschema-form";
+import "./SubmitInputGroupWidget.scss";
+
+export default ({ schema, uiSchema, value, onChange, id }) => {
+  const [data, setData] = useState(value);
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <div className="cff-submitinputgroupwidget">
+        <Form
+          tagName="div"
+          schema={schema}
+          uiSchema={uiSchema}
+          formData={data}
+          onChange={e => e.formData !== undefined && setData(e.formData)}
+          idPrefix={id + "_widget"}
+        >
+          <></>
+        </Form>
+        <span
+          className="oi oi-check icon"
+          onClick={() => onChange(data)}
+        ></span>
+      </div>
+    );
+  } else {
+    return (
+      <div className="cff-submitinputgroupwidget">
+        {value}
+        <span
+          className="oi oi-pencil icon"
+          onClick={() => setEditing(true)}
+        ></span>
+      </div>
+    );
+  }
+};


### PR DESCRIPTION
Now, groupEdit can have a schema specified without enum / enumNames. This will be rendered as follows:

![image](https://user-images.githubusercontent.com/1689183/107853064-f3c86d80-6de1-11eb-9c31-94346f1e64bb.png)

Once edited, it can be saved as follows:

![image](https://user-images.githubusercontent.com/1689183/107853072-faef7b80-6de1-11eb-9687-cba13d7cbedf.png)
